### PR TITLE
Added parameter, 'a' to specify the Server Type either 'ei' or 'microei'

### DIFF
--- a/distribution/scripts/ei/microei-start.sh
+++ b/distribution/scripts/ei/microei-start.sh
@@ -21,21 +21,22 @@ default_heap_size="1G"
 heap_size="$default_heap_size"
 cpus=""
 wso2_ei_version=""
-server_type=""
+default_server_type="microei"
+server_type="$default_server_type"
 
 function usage() {
     echo ""
     echo "Usage: "
-    echo "$0 -c <cpus> -v <wso2_ei_version> [-m <heap_size>] [-h]"
+    echo "$0 -c <cpus> -v <wso2_ei_version> [-m <heap_size>] [-a <server_type>] [-h]"
     echo "-c: Number of CPU resources to be used by the container."
     echo "-v: WSO2 Enterprise Integrator version."
     echo "-m: The heap memory size of Micro Integrator. Default: $default_heap_size."
+    echo "-a: Server Type. \"ei\" for EI and \"microei\" for Micro EI. Default: $default_server_type"
     echo "-h: Display this help and exit."
-    echo "-a: ei for EI and mei for Micro EI"
     echo ""
 }
 
-while getopts "c:v:m:ha:" opt; do
+while getopts "c:v:m:a:h" opt; do
     case "${opt}" in
     c)
         cpus=${OPTARG}
@@ -47,8 +48,8 @@ while getopts "c:v:m:ha:" opt; do
         heap_size=${OPTARG}
         ;;
     a)
-	server_type=${OPTARG}
-	;;
+	    server_type=${OPTARG}
+	    ;;
     h)
         usage
         exit 0
@@ -77,7 +78,12 @@ if [[ -z $heap_size ]]; then
 fi
 
 if [[ -z $server_type ]]; then
-    echo "Please provide ei or mei for Enterprise Integrator or Micro Integrator respectively."
+    echo "Please provide the server type."
+    exit 1
+fi
+
+if [[ $server_type != "ei" ]] && [[ $server_type != "microei" ]]; then
+    echo "Server type must be \"ei\" or \"microei\"."
     exit 1
 fi
 
@@ -101,24 +107,24 @@ chmod o+w ${HOME}/logs/gc.log
 
 # Sample CAPP location
 capp_dir=$script_dir/capp/
-echo "Starting the docker container:"
+echo "Starting the docker container for server type: $server_type"
 (
     set -x
-    if test "$server_type" = "mei"
-    then
+    if [[ "$server_type" == "microei" ]]; then
         docker run --name=microei -d -p 8280:8290 -p 8243:8253 --add-host=netty:$netty_host --cpus=${cpus} --memory=${memory} \
             --volume $(realpath $capp_dir):/home/wso2carbon/wso2ei-${wso2_ei_version}/wso2/micro-integrator/repository/deployment/server/carbonapps \
             --volume ${HOME}/logs/wso2carbon.log:/home/wso2carbon/wso2ei-${wso2_ei_version}/wso2/micro-integrator/repository/logs/wso2carbon.log \
             --volume ${HOME}/logs/gc.log:/home/wso2carbon/wso2ei-${wso2_ei_version}/wso2/micro-integrator/repository/logs/gc.log \
             -e "${JVM_MEM_OPTS}" -e "${JAVA_OPTS}" wso2ei-micro-integrator:${wso2_ei_version}
-    fi
-    if test "$server_type" = "ei"
-    then
+    elif [[ "$server_type" == "ei" ]]; then
         docker run --name=microei -d -p 8280:8280 -p 8243:8243 --add-host=netty:$netty_host --cpus=${cpus} --memory=${memory} \
             --volume $(realpath $capp_dir):/home/wso2carbon/wso2ei-${wso2_ei_version}/repository/deployment/server/carbonapps \
             --volume ${HOME}/logs/wso2carbon.log:/home/wso2carbon/wso2ei-${wso2_ei_version}/repository/logs/wso2carbon.log \
             --volume ${HOME}/logs/gc.log:/home/wso2carbon/wso2ei-${wso2_ei_version}/repository/logs/gc.log \
             -e "${JVM_MEM_OPTS}" -e "${JAVA_OPTS}" wso2ei-micro-integrator:${wso2_ei_version}
+    else
+        echo "Invalid server type."
+        exit 1
     fi
 )
 

--- a/distribution/scripts/jmeter/run-micro-ei-performance-tests.sh
+++ b/distribution/scripts/jmeter/run-micro-ei-performance-tests.sh
@@ -22,20 +22,22 @@ script_dir=$(dirname "$0")
 
 export cpus
 export wso2_ei_version
-export server_type
+export default_server_type="microei"
+export server_type="$default_server_type"
 
 function usageCommand() {
-    echo "-c <cpus> -v <wso2_ei_version>"
+    echo "-c <cpus> -v <wso2_ei_version> -a <server_type>"
 }
 export -f usageCommand
 
 function usageHelp() {
     echo "-c: Number of CPU resources to be used by the WSO2 Enterprise Micro Integrator Container."
     echo "-v: WSO2 Enterprise Integrator version."
+    echo "-a: Server Type. \"ei\" for EI and \"microei\" for Micro EI. Default: $default_server_type"
 }
 export -f usageHelp
 
-while getopts ":u:a:b:s:m:d:w:n:j:k:l:i:e:tp:hc:v:" opt; do
+while getopts ":u:b:s:m:d:w:n:j:k:l:i:e:tp:hc:v:a:" opt; do
     case "${opt}" in
     c)
         cpus=${OPTARG}
@@ -44,8 +46,8 @@ while getopts ":u:a:b:s:m:d:w:n:j:k:l:i:e:tp:hc:v:" opt; do
         wso2_ei_version=${OPTARG}
         ;;
     a)
-	server_type=${OPTARG}
-	;;
+	    server_type=${OPTARG}
+	    ;;
     *)
         opts+=("-${opt}")
         [[ -n "$OPTARG" ]] && opts+=("$OPTARG")
@@ -64,7 +66,7 @@ function validate() {
         exit 1
     fi
     if [[ -z $server_type ]]; then
-        echo "Please provide the Server Type correctly as ei or mei."
+        echo "Please provide the server type."
         exit 1
     fi
 }

--- a/distribution/scripts/jmeter/run-micro-ei-performance-tests.sh
+++ b/distribution/scripts/jmeter/run-micro-ei-performance-tests.sh
@@ -22,6 +22,7 @@ script_dir=$(dirname "$0")
 
 export cpus
 export wso2_ei_version
+export server_type
 
 function usageCommand() {
     echo "-c <cpus> -v <wso2_ei_version>"
@@ -34,7 +35,7 @@ function usageHelp() {
 }
 export -f usageHelp
 
-while getopts ":u:b:s:m:d:w:n:j:k:l:i:e:tp:hc:v:" opt; do
+while getopts ":u:a:b:s:m:d:w:n:j:k:l:i:e:tp:hc:v:" opt; do
     case "${opt}" in
     c)
         cpus=${OPTARG}
@@ -42,6 +43,9 @@ while getopts ":u:b:s:m:d:w:n:j:k:l:i:e:tp:hc:v:" opt; do
     v)
         wso2_ei_version=${OPTARG}
         ;;
+    a)
+	server_type=${OPTARG}
+	;;
     *)
         opts+=("-${opt}")
         [[ -n "$OPTARG" ]] && opts+=("$OPTARG")
@@ -57,6 +61,10 @@ function validate() {
     fi
     if [[ -z $wso2_ei_version ]]; then
         echo "Please provide WSO2 Enterprise Integrator version."
+        exit 1
+    fi
+    if [[ -z $server_type ]]; then
+        echo "Please provide the Server Type correctly as ei or mei."
         exit 1
     fi
 }
@@ -91,7 +99,7 @@ function before_execute_test_scenario() {
     fi
 
     echo "Starting Enterprise Micro Integrator..."
-    ssh $ei_ssh_host "./ei/microei-start.sh -m $heap -c $cpus -v $wso2_ei_version"
+    ssh $ei_ssh_host "./ei/microei-start.sh -m $heap -c $cpus -v $wso2_ei_version -a $server_type"
 }
 
 function after_execute_test_scenario() {


### PR DESCRIPTION
## Purpose
Added Micro EI perf test start parameter 'a' to specify the type of the server. The server type can either be EI or Micro EI as the Micro EI perf test supports Docker deployments for both of them.

## Goals
Perf test both EI and Micro EI Docker images with Micro EI perf tests.

## Approach
Added parameter 'a' to specify the type of the server